### PR TITLE
Add iteration stop criteria

### DIFF
--- a/src/leidenbase/leidenFindPartition.cpp
+++ b/src/leidenbase/leidenFindPartition.cpp
@@ -135,7 +135,7 @@ int leidenFindPartition( igraph_t *pigraph,
 {
   int correctSelfLoops;
   int status;
-  std::int32_t iiter;
+  std::int32_t iiter = 0;
 
   size_t numVertex;
   size_t numEdge;
@@ -207,9 +207,11 @@ int leidenFindPartition( igraph_t *pigraph,
   /*
    * Run optimiser.
    */
-  for( iiter = 0; iiter < numIter; ++iiter )
+  double update = 1;
+  while (iiter < numIter && update > 0)
   {
-    optimiser.optimise_partition( ppartition );
+    update = optimiser.optimise_partition( ppartition );
+    iiter++;
   }
 
   /*


### PR DESCRIPTION
The current wrapper ignores the return value of the optimizer and runs as many iterations as users specify. The iteration should stop when no more optimization can be made. SImilar criteria are also seen in other leiden/louvain wrapper packages such as [leidenAlg](https://github.com/kharchenkolab/leidenAlg/blob/2934af61d8404adda23203fcfd2f22605f95576f/src/leiden.cpp#L82C5-L82C8), [Seurat](https://github.com/satijalab/seurat/blob/763259d05991d40721dee99c9919ec6d4491d15e/src/ModularityOptimizer.cpp#L973) and the original [leidenalg](https://github.com/vtraag/leidenalg/blob/918eebf679c8fb43325227eefbf9b1bde472ba92/src/leidenalg/Optimiser.py#L727C32-L727C32). 